### PR TITLE
Upgrade OpenCV to 3.4.8

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -3,7 +3,7 @@ FROM nvidia/cuda:8.0-devel-ubuntu16.04
 
 ENV FAISS_CPU_OR_GPU "cpu"
 ENV FAISS_VERSION "1.3.0"
-ENV OPENCV_VERSION "3.4.1"
+ENV OPENCV_VERSION "3.4.8"
 
 RUN apt-get update && apt-get install -y curl bzip2 libgl1-mesa-glx
 


### PR DESCRIPTION
Fixes error https://github.com/worldveil/photomosaic/issues/10:

```
ImportErrorTraceback (most recent call last)
in ()
----> 1 import cv2

ImportError: libx264.so.138: cannot open shared object file: No such file or directory
```