### PR TITLE
Installation issues and Windows run script

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -7,7 +7,7 @@ ENV OPENCV_VERSION "3.4.8"
 
 RUN apt-get update && apt-get install -y curl bzip2 libgl1-mesa-glx
 
-RUN curl https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh > /tmp/conda.sh
+RUN curl -L https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh > /tmp/conda.sh
 RUN bash /tmp/conda.sh -b -p /opt/conda && \
     /opt/conda/bin/conda update -n base conda && \
     /opt/conda/bin/conda install -y -c pytorch faiss-${FAISS_CPU_OR_GPU}=${FAISS_VERSION} && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ scikit-image==0.14.0
 moviepy==0.2.3.5
 tqdm==4.26.0
 dlib
-imutils
+imutils==0.5.3
+imageio<2.7

--- a/run_powershell.ps1
+++ b/run_powershell.ps1
@@ -1,1 +1,21 @@
-docker run --rm --name Photomosaic --mount type=bind, source="C:\Users\ixb20175\Desktop\Projects\Docker\photomosaic", target="/project" --mount type=bind, source="C:\Users\ixb20175\Pictures", target="/pics" -p "8888:8888/tcp" -e "DISPLAY=
+param($PicturesDir="c:\Users\$env:UserName\Pictures", $ProjectDir="$pwd", $ContainerName="Photomosaic")
+
+$env:HostIP = (
+    Get-NetIPConfiguration |
+    Where-Object {
+        $_.IPv4DefaultGateway -ne $null -and
+        $_.NetAdapter.Status -ne "Disconnected"
+    }
+).IPv4Address.IPAddress
+
+docker run --rm --name $ContainerName `
+	--mount type=bind,source="$ProjectDir",target="/project" `
+	--mount type=bind,source="$PicturesDir",target="/pics" `
+	-p "8888:8888/tcp" -e "DISPLAY=$env:HostIP:0" `
+	mosaic-conda:latest `
+	jupyter notebook `
+		--allow-root `
+		--ip 0.0.0.0 `
+		--no-browser `
+		--NotebookApp.token='' `
+		--notebook-dir=/project

--- a/run_powershell.ps1
+++ b/run_powershell.ps1
@@ -1,0 +1,1 @@
+docker run --rm --name Photomosaic --mount type=bind, source="C:\Users\ixb20175\Desktop\Projects\Docker\photomosaic", target="/project" --mount type=bind, source="C:\Users\ixb20175\Pictures", target="/pics" -p "8888:8888/tcp" -e "DISPLAY=


### PR DESCRIPTION
In this pull request, I'm simply solving some issues I ran into when trying to install your lib on windows 10. 
Relates to #13 and #15.

There are three simple changes:

1. Dockerfile.cpu: the installation was not being successful due to the missed installation of miniconda2. According to [this asnwer](https://stackoverflow.com/a/63367463/6945436), the issue was given by `curl`, which does not automatically follow redirects unless the option `-L` is provided. This indeed solved the issue.
2. requirements.txt: `imageio` package was required to be within a certain version range, but without clearly stating it inside the requirements.txt document, the package installer was installing the latest version, thus the addition of the version specification.
3. run_powershell.ps1: simple script which mimics `launch.sh`, but in a PowerShell compatible mode.

Thanks for your work!
