### PR TITLE
Update dockerfile and requirements to pin versions

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,5 +1,5 @@
 # https://github.com/plippe/faiss-docker/blob/master/Dockerfile
-FROM nvidia/cuda:8.0-devel-ubuntu16.04
+FROM --platform=linux/amd64 nvidia/cuda:11.8.0-devel-ubuntu22.04
 
 ENV FAISS_CPU_OR_GPU "cpu"
 ENV FAISS_VERSION "1.3.0"
@@ -7,7 +7,7 @@ ENV OPENCV_VERSION "3.4.8"
 
 RUN apt-get update && apt-get install -y curl bzip2 libgl1-mesa-glx
 
-RUN curl https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh > /tmp/conda.sh
+RUN curl -L https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh > /tmp/conda.sh
 RUN bash /tmp/conda.sh -b -p /opt/conda && \
     /opt/conda/bin/conda update -n base conda && \
     /opt/conda/bin/conda install -y -c pytorch faiss-${FAISS_CPU_OR_GPU}=${FAISS_VERSION} && \
@@ -38,7 +38,7 @@ RUN apt-get update -y && \
         libpq-dev \
         libopenblas-dev \
         liblapack3 \
-        python-dev \
+        python2-dev \
         swig \
         git \
         python-pip \

--- a/launch.sh
+++ b/launch.sh
@@ -12,7 +12,7 @@ docker run \
 	--rm \
 	--name $CONTAINER_NAME \
 	--mount type=bind,source="$(pwd)",target=/project \
-	--mount type=bind,source="$HOME/Dropbox/Camera Uploads/",target=/pics \
+	--mount type=bind,source="$HOME/",target=/pics \
 	-p "$PORT:$PORT/tcp" \
 	-e "DISPLAY=$IP:0" \
 	mosaic-conda:latest \

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ scikit-image==0.14.0
 moviepy==0.2.3.5
 tqdm==4.26.0
 dlib
-imutils
+imutils==0.5.3
+imageio<2.7


### PR DESCRIPTION
This PR fixes issues raised in #17 and #15.
The only difference between this and #16 are:
- the addition of the `--platform` tag on the nvidia/cuda image
- a new nvidia/cuda image tag
- replacing `python-dev` with `python2-dev`
- lack of the powershell script